### PR TITLE
fixed errors

### DIFF
--- a/src/lib/index.coffee
+++ b/src/lib/index.coffee
@@ -32,7 +32,7 @@ class Coffee
 
 			filter: (filepath) =>
 
-				return @regex.test filepath
+				return filepath.match @regex
 
 			output: (filepath) =>
 

--- a/src/lib/index.coffee
+++ b/src/lib/index.coffee
@@ -58,7 +58,7 @@ class Coffee
 
 					return done null
 
-				catch then return done err			
+				catch err then return done err			
 
 			plugin: (files, metalsmith, done) ->
 


### PR DESCRIPTION
RegExp.test does store some state in the RegExp-Object ([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test): As with exec (or in combination with it), test called multiple times on the same global regular expression instance will advance past the previous match.), instead you probably want to use String.match.

I encountered this error when some of my coffee files weren't compiled. The order of all files tested was:
`designer.jade`
`index.jade`
`css\bootstrap-theme.css`
`css\bootstrap-theme.css.map`
`fonts\glyphicons-halflings-regular.eot`
`fonts\glyphicons-halflings-regular.ttf`
`css\bootstrap.css`
`fonts\glyphicons-halflings-regular.woff`
`images\tree.png`
`fonts\glyphicons-halflings-regular.svg`
`js\doccookies.js`
`js\bootstrap.js`
`js\export_modules.js`
`scripts\animation.coffee`
`scripts\flip_animation.coffee`
`js\jquery-2.1.1.min.js`
`scripts\animation_manager.coffee`
`js\query-string.js`
`scripts\forward_to_designer.coffee`
`scripts\main.coffee`
`scripts\prefixedCSS.coffee`
`scripts\puzzle_desinger.coffee`
`scripts\puzzle.coffee`
`scripts\render_greetings.coffee`
`scripts\unflip_animation.coffee`
`scripts\tutorial.coffee`
`scripts\word_wrap.coffee`
`style\app.styl`
`css\bootstrap.css.map`
`js\jquery-1.11.1.js`
`images\tree2.png`
`images\tree4.png`
`images\tree3.png`

Out of these
`scripts\flip_animation.coffee`
`scripts\main.coffee`
`scripts\puzzle_desinger.coffee`
`scripts\unflip_animation.coffee`
`scripts\word_wrap.coffee`
were not selected by the filter and in turn not compiled.
